### PR TITLE
Add non-TTY environment guidance for Windows/CI

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -19,6 +19,22 @@ ConoHa VPS3 CLIを使ったインフラ構築ガイド。
 - `conoha auth login` で認証済みであること
 - SSHキーペアが登録済みであること（`conoha keypair create <name>`）
 
+## 非TTY環境（Windows等）での注意事項
+
+Windows（Windows Server 2019等）やCI/CD環境など、TTYが利用できない環境では対話的なプロンプトが動作しない。以下のルールに従うこと：
+
+1. **`--no-input` フラグを付与する** — すべてのコマンドにグローバルフラグ `--no-input` を付けることで、対話プロンプトを無効化できる
+2. **必須パラメータをすべてフラグで指定する** — 省略すると対話的選択が発生し `interactive selection requires a TTY` エラーになる
+3. **`conoha server create` では `--flavor`、`--image`、`--key-name` を必ず指定する**
+4. **`conoha app` サブコマンドでは `--app-name` を必ず指定する** — 省略するとアプリ名の入力プロンプトが発生する
+5. **破壊的コマンド（delete、destroy、stop）は `--yes` フラグで確認をスキップする**
+
+```bash
+# 非TTY環境での例
+conoha server create --name my-server --flavor <ID> --image <ID> --key-name <キー名> --no-input --wait
+conoha app deploy my-server --app-name myapp --no-input
+```
+
 ## 基本操作
 
 ### サーバー管理
@@ -27,7 +43,7 @@ ConoHa VPS3 CLIを使ったインフラ構築ガイド。
 |---------|------|
 | `conoha server list` | サーバー一覧を表示する |
 | `conoha server create --name <名前> --flavor <ID> --image <ID> --key-name <キー名>` | サーバーを作成する |
-| `conoha server create --name <名前> --wait` | サーバー作成完了まで待機する |
+| `conoha server create --name <名前> --flavor <ID> --image <ID> --key-name <キー名> --wait` | サーバー作成完了まで待機する |
 | `conoha server show <ID\|名前>` | サーバー詳細を表示する |
 | `conoha server delete <ID\|名前>` | サーバーを削除する |
 | `conoha server deploy <ID\|名前> --script <ファイル> --env KEY=VALUE` | スクリプトをSSH経由で実行する |

--- a/SKILL.md
+++ b/SKILL.md
@@ -23,16 +23,20 @@ ConoHa VPS3 CLIを使ったインフラ構築ガイド。
 
 Windows（Windows Server 2019等）やCI/CD環境など、TTYが利用できない環境では対話的なプロンプトが動作しない。以下のルールに従うこと：
 
-1. **`--no-input` フラグを付与する** — すべてのコマンドにグローバルフラグ `--no-input` を付けることで、対話プロンプトを無効化できる
-2. **必須パラメータをすべてフラグで指定する** — 省略すると対話的選択が発生し `interactive selection requires a TTY` エラーになる
+1. **`--no-input` フラグを付与する** — すべてのコマンドにグローバルフラグ `--no-input` を付けることで、対話プロンプトを無効化できる。CI/CDパイプラインでは環境変数 `CONOHA_NO_INPUT=1` を設定する方が便利な場合がある
+2. **必須パラメータをすべてフラグで指定する** — 省略すると対話的プロンプトが発生しエラーになる（例: `interactive selection requires a TTY`）
 3. **`conoha server create` では `--flavor`、`--image`、`--key-name` を必ず指定する**
 4. **`conoha app` サブコマンドでは `--app-name` を必ず指定する** — 省略するとアプリ名の入力プロンプトが発生する
-5. **破壊的コマンド（delete、destroy、stop）は `--yes` フラグで確認をスキップする**
+5. **破壊的コマンド（server delete、app destroy、app stop等）は `--yes` フラグで確認をスキップする**（環境変数: `CONOHA_YES=1`）
 
 ```bash
 # 非TTY環境での例
 conoha server create --name my-server --flavor <ID> --image <ID> --key-name <キー名> --no-input --wait
 conoha app deploy my-server --app-name myapp --no-input
+
+# CI/CDパイプラインでは環境変数でまとめて設定可能
+export CONOHA_NO_INPUT=1
+export CONOHA_YES=1
 ```
 
 ## 基本操作
@@ -77,12 +81,12 @@ conoha app deploy my-server --app-name myapp --no-input
 
 | コマンド | 説明 |
 |---------|------|
-| `conoha app init <ID\|名前>` | サーバーにDocker環境を初期化する |
-| `conoha app deploy <ID\|名前>` | カレントディレクトリをサーバーにデプロイする |
-| `conoha app status <ID\|名前>` | アプリのコンテナ状態を表示する |
-| `conoha app logs <ID\|名前> --follow` | アプリのログをストリーミング表示する |
-| `conoha app stop <ID\|名前>` | アプリのコンテナを停止する |
-| `conoha app restart <ID\|名前>` | アプリのコンテナを再起動する |
+| `conoha app init <ID\|名前> --app-name <アプリ名>` | サーバーにDocker環境を初期化する |
+| `conoha app deploy <ID\|名前> --app-name <アプリ名>` | カレントディレクトリをサーバーにデプロイする |
+| `conoha app status <ID\|名前> --app-name <アプリ名>` | アプリのコンテナ状態を表示する |
+| `conoha app logs <ID\|名前> --app-name <アプリ名> --follow` | アプリのログをストリーミング表示する |
+| `conoha app stop <ID\|名前> --app-name <アプリ名>` | アプリのコンテナを停止する |
+| `conoha app restart <ID\|名前> --app-name <アプリ名>` | アプリのコンテナを再起動する |
 
 ## レシピ一覧
 

--- a/recipes/figma-to-deploy.md
+++ b/recipes/figma-to-deploy.md
@@ -135,16 +135,18 @@ conoha server create --name my-figma-app --flavor <フレーバーID> --image <U
 Docker環境を初期化してデプロイする：
 
 ```bash
-conoha app init my-figma-app
-conoha app deploy my-figma-app
+conoha app init my-figma-app --app-name myapp
+conoha app deploy my-figma-app --app-name myapp
 ```
+
+> **非TTY環境**: `--app-name` を省略するとアプリ名の入力プロンプトが発生する。Windows等の非TTY環境では必ず指定すること。
 
 ### 6. 動作確認
 
 コンテナの状態を確認する：
 
 ```bash
-conoha app status my-figma-app
+conoha app status my-figma-app --app-name myapp
 ```
 
 ブラウザでサーバーIPにアクセスし、以下を確認する：
@@ -186,6 +188,6 @@ conoha dns record create --zone-id <ゾーンID> --name www --type A --data <サ
 |------|------|
 | Figma MCPに接続できない | APIトークンの有効性を確認する。`~/.claude/settings.json` のMCPサーバー設定を確認する |
 | `npm run build` が失敗する | Node.jsバージョンを確認する（LTS推奨）。依存パッケージの競合を `npm ls` で確認する |
-| デプロイ後にページが表示されない | `conoha app logs my-figma-app` でエラーを確認する |
+| デプロイ後にページが表示されない | `conoha app logs my-figma-app --app-name myapp` でエラーを確認する |
 | Nginx 404エラー | `nginx.conf` の `try_files` 設定を確認する。SPA対応が必要 |
 | セキュリティグループでブロック | ポート80（HTTP）が開放されているか確認する |

--- a/recipes/single-server-app.md
+++ b/recipes/single-server-app.md
@@ -49,8 +49,10 @@ conoha server create --name my-app-server --flavor <フレーバーID> --image <
 サーバーにDocker環境をセットアップする：
 
 ```bash
-conoha app init my-app-server
+conoha app init my-app-server --app-name myapp
 ```
+
+> **非TTY環境**: `--app-name` を省略するとアプリ名の入力プロンプトが発生する。Windows等の非TTY環境では必ず指定すること。
 
 これにより以下が実行される：
 - Docker/Docker Composeのインストール
@@ -61,7 +63,7 @@ conoha app init my-app-server
 カレントディレクトリ（`docker-compose.yml` があるディレクトリ）で実行する：
 
 ```bash
-conoha app deploy my-app-server
+conoha app deploy my-app-server --app-name myapp
 ```
 
 これにより以下が実行される：
@@ -75,10 +77,10 @@ conoha app deploy my-app-server
 
 ```bash
 # コンテナ状態を確認する
-conoha app status my-app-server
+conoha app status my-app-server --app-name myapp
 
 # ログを確認する
-conoha app logs my-app-server --follow
+conoha app logs my-app-server --app-name myapp --follow
 
 # 直接SSHでアクセスする場合
 ssh root@<サーバーIP> "curl -s localhost:<ポート>"
@@ -91,8 +93,8 @@ ssh root@<サーバーIP> "curl -s localhost:<ポート>"
 サーバー側に永続的な環境変数を設定する（デプロイを跨いで維持される）：
 
 ```bash
-conoha app env set my-app-server DATABASE_URL=postgres://...
-conoha app env list my-app-server
+conoha app env set my-app-server --app-name myapp DATABASE_URL=postgres://...
+conoha app env list my-app-server --app-name myapp
 ```
 
 または、ローカルに `.env.server` ファイルを作成してデプロイ時に自動コピーさせる。
@@ -101,13 +103,13 @@ conoha app env list my-app-server
 
 ```bash
 # 停止
-conoha app stop my-app-server
+conoha app stop my-app-server --app-name myapp
 
 # 再起動
-conoha app restart my-app-server
+conoha app restart my-app-server --app-name myapp
 
 # ログ（特定サービス）
-conoha app logs my-app-server --service web
+conoha app logs my-app-server --app-name myapp --service web
 ```
 
 ## トラブルシューティング


### PR DESCRIPTION
## Summary

- Add non-TTY (Windows/CI) guidance section to SKILL.md with `--no-input`, `--app-name`, `--yes` flag usage
- Fix incomplete `server create` example that was missing `--flavor`/`--image`/`--key-name` flags
- Add `--app-name` flag to all `conoha app` commands in single-server-app and figma-to-deploy recipes

Closes #1