### PR TITLE
security: harden recipe examples and add secret-handling guard rails

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,22 @@
+name: gitleaks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "true"
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Secret files (NEVER commit any of these)
+.env
+.env.*
+!.env.example
+!.env.*.example
+*.pem
+*.key
+*.p12
+*.pfx
+id_rsa*
+id_ed25519*
+*credentials*
+!*credentials*.example
+.netrc
+
+# Working memos / handoff notes — keep out of git
+docs/memory/
+
+# OS / editor
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+.idea/
+.vscode/
+
+# Build artifacts
+node_modules/
+dist/
+build/
+__pycache__/
+*.pyc
+.pytest_cache/
+
+# Claude Code local state
+.claude/
+.worktrees/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing
+
+## Secret-handling rules (must read)
+
+This repository ships Claude Code "skills" (recipes and automation
+scripts) that direct an agent to provision real ConoHa infrastructure.
+Recipes are copied verbatim by users, so any value baked into a command
+example is something the user is likely to run as-is.
+
+To prevent the kind of incident where production-looking data leaks into
+samples, contributors **must** follow these rules:
+
+1. **No hardcoded passwords or tokens in command examples.** Replace
+   them with `$(openssl rand -base64 24)` (generated at runtime) or
+   `<PLACEHOLDER>` (forces the user to substitute). Never write
+   `--env ADMIN_PASSWORD=SecurePass123` or similar — users will copy
+   that into production.
+
+2. **No real IPs, VM IDs, hostnames, SSH key names, or tenant IDs.**
+   Use `<SERVER_IP>`, `<VM_ID>`, `<TENANT_ID>` placeholders. For
+   documentation IPs use the RFC 5737 reserved ranges
+   (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`).
+
+3. **No insecure SSH options as defaults.** `StrictHostKeyChecking=no`
+   creates a MITM vulnerability. If you must show it for a "first run"
+   case, mark it clearly as test-only and pair it with a comment
+   explaining how to do it securely (`ssh-keyscan` + `known_hosts`).
+
+4. **Don't pass secrets via `--env` (process list / API logs).**
+   Cluster keys, SSH private keys, and similar secrets must travel via
+   `--upload` (file copy with restricted perms) or a secrets manager,
+   not as environment variables that show up in `ps aux` and the
+   ConoHa API request log.
+
+5. **Pre-publish drafts and handoff memos belong outside git.**
+   `docs/memory/` is gitignored.
+
+## How we enforce this
+
+* **`gitleaks` runs on every PR** via GitHub Actions
+  (`.github/workflows/gitleaks.yml`). PRs with detected secrets are
+  blocked from merge.
+* **`.gitignore`** blocks `.env`, `.env.*`, `*.pem`, `*.key`,
+  `id_rsa*`, `*credentials*`, and `docs/memory/`.
+* **Reviewers should grep PRs** for:
+  * known token prefixes (`sk_`, `pk_`, `whsec_`, `hf_`, `Bearer `)
+  * literal IPs (any `\d+\.\d+\.\d+\.\d+`)
+  * `password=`, `token=`, `secret=` followed by a non-placeholder
+  * `StrictHostKeyChecking=no`
+
+## If you accidentally commit a secret
+
+1. **Rotate it immediately at the source service** — assume the value
+   is already public.
+2. After rotating, remove the value from `HEAD` in a follow-up commit.
+3. To purge it from git history, use `git filter-repo` and force-push,
+   then notify other contributors so they re-clone. Do this only after
+   rotation.

--- a/recipes/openstack-platform.md
+++ b/recipes/openstack-platform.md
@@ -121,7 +121,8 @@ echo "DevStack installation complete"
 
 ```bash
 HOST_IP=$(conoha server show openstack-aio -o json | jq -r '.addresses | to_entries[0].value[] | select(.version == 4) | .addr')
-conoha server deploy openstack-aio --script openstack-setup.sh --env ADMIN_PASSWORD=SecurePass123 --env HOST_IP=$HOST_IP
+ADMIN_PASSWORD=$(openssl rand -base64 24)  # 強いランダム値を生成。ログには絶対に残さない
+conoha server deploy openstack-aio --script openstack-setup.sh --env ADMIN_PASSWORD="$ADMIN_PASSWORD" --env HOST_IP=$HOST_IP
 ```
 
 注意: DevStackのインストールには20〜40分かかる。`conoha server deploy` のタイムアウトに注意する。

--- a/recipes/slurm-cluster.md
+++ b/recipes/slurm-cluster.md
@@ -111,17 +111,21 @@ echo "Common setup complete for $NODE_ROLE"
 conoha server deploy slurm-controller --script slurm-common.sh --env CTRL_IP=$CTRL_IP --env COMP1_IP=$COMP1_IP --env COMP2_IP=$COMP2_IP --env NODE_ROLE=controller
 ```
 
-コントローラーからMungeキーを取得する：
+コントローラーからMungeキーをファイルに取得する。`--env` で平文渡しすると
+プロセスリスト (`ps aux`) と ConoHa API リクエストログに残るため、必ず
+ファイル経由で配布する：
 
 ```bash
-MUNGE_KEY=$(ssh root@$CTRL_IP "base64 /etc/munge/munge.key")
+ssh root@$CTRL_IP "cat /etc/munge/munge.key" > /tmp/munge.key
+chmod 600 /tmp/munge.key
 ```
 
-コンピュートノードで共通セットアップを実行する：
+コンピュートノードで共通セットアップを実行する。Mungeキーは `--upload` で
+スクリプトの外側からファイルとして転送する：
 
 ```bash
-conoha server deploy slurm-compute-1 --script slurm-common.sh --env CTRL_IP=$CTRL_IP --env COMP1_IP=$COMP1_IP --env COMP2_IP=$COMP2_IP --env NODE_ROLE=compute --env MUNGE_KEY_BASE64="$MUNGE_KEY"
-conoha server deploy slurm-compute-2 --script slurm-common.sh --env CTRL_IP=$CTRL_IP --env COMP1_IP=$COMP1_IP --env COMP2_IP=$COMP2_IP --env NODE_ROLE=compute --env MUNGE_KEY_BASE64="$MUNGE_KEY"
+conoha server deploy slurm-compute-1 --script slurm-common.sh --env CTRL_IP=$CTRL_IP --env COMP1_IP=$COMP1_IP --env COMP2_IP=$COMP2_IP --env NODE_ROLE=compute --upload /tmp/munge.key:/etc/munge/munge.key
+conoha server deploy slurm-compute-2 --script slurm-common.sh --env CTRL_IP=$CTRL_IP --env COMP1_IP=$COMP1_IP --env COMP2_IP=$COMP2_IP --env NODE_ROLE=compute --upload /tmp/munge.key:/etc/munge/munge.key
 ```
 
 ### 4. コントローラーセットアップ
@@ -196,7 +200,11 @@ mount $CTRL_IP:/shared /shared
 echo "$CTRL_IP:/shared /shared nfs defaults 0 0" >> /etc/fstab
 
 # コントローラーからslurm.confをコピー
-scp -o StrictHostKeyChecking=no root@$CTRL_IP:/etc/slurm/slurm.conf /etc/slurm/slurm.conf
+# 本番では事前にホスト鍵を /root/.ssh/known_hosts に登録するか、
+# `ssh-keyscan -H $CTRL_IP >> ~/.ssh/known_hosts` を初期化スクリプトで実行する。
+# StrictHostKeyChecking=no は MITM 攻撃の余地を作るため、テスト用途以外では避ける。
+ssh-keyscan -H "$CTRL_IP" >> /root/.ssh/known_hosts
+scp root@$CTRL_IP:/etc/slurm/slurm.conf /etc/slurm/slurm.conf
 
 # slurmd起動
 mkdir -p /var/spool/slurmd


### PR DESCRIPTION
## Summary

Audit triggered by the Money Forward incident (test code containing near-production data). Recipes in this repo are copied verbatim by users, so a hardcoded value baked into a command example becomes the value the user actually runs.

### What this PR does

- `recipes/openstack-platform.md`: replaced hardcoded `ADMIN_PASSWORD=SecurePass123` with `\$(openssl rand -base64 24)` so the recipe doesn't ship a known password.
- `recipes/slurm-cluster.md`:
  - Munge cluster key no longer travels via `--env MUNGE_KEY_BASE64=...` (which exposes it in `ps aux` and the ConoHa API request log). Switched to file-based distribution via `--upload`.
  - Removed `StrictHostKeyChecking=no` from the slurm.conf scp step. Replaced with `ssh-keyscan` into `known_hosts`, with a comment explaining why the disabled option is unsafe.
- New `.gitignore` (the repo previously had none): blocks `.env`, `.env.*`, `*.pem`, `*.key`, `id_rsa*`, `*credentials*`, `docs/memory/`, and common build/editor cruft.
- New `CONTRIBUTING.md` documenting the rules: no hardcoded passwords/tokens, no real IPs/VM IDs, no `StrictHostKeyChecking=no` defaults, no secrets via `--env`.
- New `.github/workflows/gitleaks.yml` for automated scanning.

## Test plan

- [ ] Confirm recipe text still flows naturally with the placeholders
- [ ] CI: gitleaks workflow runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)