### PR TITLE
SKILL: add 'conoha app reset' to lifecycle table

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -100,6 +100,7 @@ export CONOHA_YES=1
 | `conoha app stop <server> --app-name <app>` | コンテナを停止 |
 | `conoha app restart <server> --app-name <app>` | コンテナを再起動 |
 | `conoha app destroy <server> --app-name <app> --yes` | アプリをサーバーから完全削除 (非対話) |
+| `conoha app reset <server> --app-name <app> --yes` | `destroy` + `init` + `deploy` を 1 SSH セッションで連続実行 (再デプロイ用、v0.5.6 以降)。`app env set` で投入した値は `destroy` で消えるため、必要なら直前に export して再投入する |
 | `conoha app list <server>` | サーバー上のデプロイ済みアプリ一覧 |
 | `conoha app env set <server> --app-name <app> KEY=VALUE` | サーバー側永続環境変数を設定 |
 | `conoha app env list/get/unset` | 環境変数の一覧・取得・削除 |


### PR DESCRIPTION
## Summary

Adds `conoha app reset` to the `app` lifecycle table in SKILL.md.

Upstream `conoha-cli` v0.5.6 ([PR #74](https://github.com/crowdy/conoha-cli/pull/74)) added `app reset`, which combines `destroy` + `init` + `deploy` into a single SSH session for the redeploy workflow. The skill currently doesn't mention it, so Claude sessions still synthesize the three commands manually.

The doc entry also flags the env-loss caveat: the embedded `destroy` step wipes values previously set via `app env set` (upstream commit `4aedc98` documents this), so the operator should re-export before reset.

Closes #4 (actionable issue with checklist), #3 (tracking issue, duplicate of #4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)