### PR TITLE
recipes(single-server-app): clarify deploy archive scope

### DIFF
--- a/recipes/single-server-app.md
+++ b/recipes/single-server-app.md
@@ -188,4 +188,4 @@ conoha app init my-app-server --app-name myapp --no-proxy   # または --proxy 
 | `docker compose up` が失敗 | `conoha app logs` でエラー確認 |
 | ポートにアクセス不可 (no-proxy) | セキュリティグループで `docker-compose.yml` の `ports` が開放されているか確認 |
 | Let's Encrypt 発行失敗 (proxy) | DNS A レコードが VPS を指しているか、ポート 80 が到達可能かを確認 |
-| デプロイが遅い | `.dockerignore` で `node_modules` 等を除外 |
+| デプロイが遅い / `Warning: skipping symlink frontend/node_modules/.bin/...` が大量に出る | `conoha app deploy` のアーカイブは `.git/` のみ除外 — `node_modules/` (Node) や `.next/`、`__pycache__/`、`venv/` 等はそのままアップロードされる。デプロイ前に `rm -rf node_modules .next` するか、ビルド成果物を含まないクリーンチェックアウトから走らせる。**`.dockerignore` は Docker ビルドコンテキストには効くがアーカイブ自体には影響しない** ことに注意 |


### PR DESCRIPTION
## Summary

Replaces the misleading 「`.dockerignore` で `node_modules` 等を除外」 troubleshooting line. As issue #6 points out (and the [linked Qiita writeup](https://qiita.com/crowdy/items/5a28aedba346d85b2930) confirms), `.dockerignore` only affects Docker build context — the tarball that `conoha app deploy` uploads is governed by the CLI itself, which currently only excludes `.git/`. So `node_modules/` (≈450 MB on Next.js), `.next/`, `__pycache__/`, `venv/` etc. all ship in full and trigger a flood of `Warning: skipping symlink ...` lines.

The new entry:
- adds the symlink-warning string so users find this row by searching the visible error
- enumerates the common offenders (Node, Next, Python venv) instead of just `node_modules`
- recommends cleaning the working tree pre-deploy or running from a fresh checkout
- explicitly calls out the `.dockerignore` ≠ archive distinction so the next reader doesn't make the same wrong jump

Closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)